### PR TITLE
add cp312 support (v0.3.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: '{cp36,cp37,cp38,cp39,cp310,cp311}-{manylinux_x86_64,manylinux_aarch64,win32,win_amd64,macosx_x86_64} {cp39,cp310,cp311}-macosx_arm64'
+          CIBW_BUILD: '{cp36,cp37,cp38,cp39,cp310,cp311,cp312}-{manylinux_x86_64,manylinux_aarch64,win32,win_amd64,macosx_x86_64} {cp39,cp310,cp311,cp312}-macosx_arm64'
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: 'auto aarch64'
           CIBW_ARCHS_MACOS: 'auto arm64'

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ EXT_MODULES = [
     ),
 ]
 
-VERSION = "0.3.3"
+VERSION = "0.3.4"
 URL = "https://github.com/escherba/python-metrohash"
 
 
@@ -162,6 +162,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Software Development :: Libraries",
         "Topic :: System :: Distributed Computing",

--- a/src/metrohash.cpp
+++ b/src/metrohash.cpp
@@ -1533,7 +1533,7 @@ static const char __pyx_k_main[] = "__main__";
 static const char __pyx_k_name[] = "__name__";
 static const char __pyx_k_seed[] = "seed";
 static const char __pyx_k_test[] = "__test__";
-static const char __pyx_k_0_3_3[] = "0.3.3";
+static const char __pyx_k_0_3_4[] = "0.3.4";
 static const char __pyx_k_email[] = "__email__";
 static const char __pyx_k_author[] = "__author__";
 static const char __pyx_k_buffer[] = "buffer";
@@ -1570,7 +1570,7 @@ static const char __pyx_k_has_incorrect_type_expected[] = "' has incorrect type:
 static const char __pyx_k_escherba_metrohash_gmail_com[] = "escherba+metrohash@gmail.com";
 static const char __pyx_k_Python_wrapper_for_MetroHash_a[] = "\nPython wrapper for MetroHash, a fast non-cryptographic hashing algorithm\n";
 static const char __pyx_k_no_default___reduce___due_to_non[] = "no default __reduce__ due to non-trivial __cinit__";
-static PyObject *__pyx_kp_u_0_3_3;
+static PyObject *__pyx_kp_u_0_3_4;
 static PyObject *__pyx_kp_u_Argument;
 static PyObject *__pyx_kp_u_Eugene_Scherba;
 static PyObject *__pyx_n_s_MemoryError;
@@ -5579,7 +5579,7 @@ static struct PyModuleDef __pyx_moduledef = {
 #endif
 
 static __Pyx_StringTabEntry __pyx_string_tab[] = {
-  {&__pyx_kp_u_0_3_3, __pyx_k_0_3_3, sizeof(__pyx_k_0_3_3), 0, 1, 0, 0},
+  {&__pyx_kp_u_0_3_4, __pyx_k_0_3_4, sizeof(__pyx_k_0_3_4), 0, 1, 0, 0},
   {&__pyx_kp_u_Argument, __pyx_k_Argument, sizeof(__pyx_k_Argument), 0, 1, 0, 0},
   {&__pyx_kp_u_Eugene_Scherba, __pyx_k_Eugene_Scherba, sizeof(__pyx_k_Eugene_Scherba), 0, 1, 0, 0},
   {&__pyx_n_s_MemoryError, __pyx_k_MemoryError, sizeof(__pyx_k_MemoryError), 0, 0, 1, 1},
@@ -6101,7 +6101,7 @@ if (!__Pyx_RefNanny) {
  * 
  * __author__  = "Eugene Scherba"             # <<<<<<<<<<<<<<
  * __email__   = "escherba+metrohash@gmail.com"
- * __version__ = "0.3.3"
+ * __version__ = "0.3.4"
  */
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_author, __pyx_kp_u_Eugene_Scherba) < 0) __PYX_ERR(0, 11, __pyx_L1_error)
 
@@ -6109,7 +6109,7 @@ if (!__Pyx_RefNanny) {
  * 
  * __author__  = "Eugene Scherba"
  * __email__   = "escherba+metrohash@gmail.com"             # <<<<<<<<<<<<<<
- * __version__ = "0.3.3"
+ * __version__ = "0.3.4"
  * __all__     = [
  */
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_email, __pyx_kp_u_escherba_metrohash_gmail_com) < 0) __PYX_ERR(0, 12, __pyx_L1_error)
@@ -6117,15 +6117,15 @@ if (!__Pyx_RefNanny) {
   /* "metrohash.pyx":13
  * __author__  = "Eugene Scherba"
  * __email__   = "escherba+metrohash@gmail.com"
- * __version__ = "0.3.3"             # <<<<<<<<<<<<<<
+ * __version__ = "0.3.4"             # <<<<<<<<<<<<<<
  * __all__     = [
  *     "MetroHash64",
  */
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_version, __pyx_kp_u_0_3_3) < 0) __PYX_ERR(0, 13, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_version, __pyx_kp_u_0_3_4) < 0) __PYX_ERR(0, 13, __pyx_L1_error)
 
   /* "metrohash.pyx":14
  * __email__   = "escherba+metrohash@gmail.com"
- * __version__ = "0.3.3"
+ * __version__ = "0.3.4"
  * __all__     = [             # <<<<<<<<<<<<<<
  *     "MetroHash64",
  *     "MetroHash128",

--- a/src/metrohash.pyx
+++ b/src/metrohash.pyx
@@ -10,7 +10,7 @@ Python wrapper for MetroHash, a fast non-cryptographic hashing algorithm
 
 __author__  = "Eugene Scherba"
 __email__   = "escherba+metrohash@gmail.com"
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __all__     = [
     "MetroHash64",
     "MetroHash128",


### PR DESCRIPTION
Hi :wave: based onthe previous PR that add support for python 3.11 (https://github.com/escherba/python-metrohash/pull/24), I open a PR to add support for python 3.12.

