### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-24.04, windows-2019, macOS-10.15]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
           path: ./wheelhouse/*.whl
   build_sdist:
     name: Build a source distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
           path: dist/*.tar.gz
   publish:
     name: 'Upload to PyPI/TestPyPI'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [build_wheels, build_sdist]
     steps:
       - name: Set up Python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: 'pytest -s {project}/tests'
           CIBW_TEST_SKIP: '*-macosx_arm64'  # Until the day Apple silicon instances are available on GitHub Actions
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
   build_sdist:
@@ -58,7 +58,7 @@ jobs:
         run: |
           pip install py-cpuinfo
           python setup.py build sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
   publish:


### PR DESCRIPTION
I bump two outdated dependencies that cause the CI to fail:
- `ubuntu-20.04` is not supported,
- `actions/upload-artifact`,